### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM node:18-alpine as frontend_build
+
+ARG FRONTEND_VERSION
+
+WORKDIR /
+
+RUN apk add git && \
+    git clone --depth 1 --branch "${FRONTEND_VERSION}" https://github.com/gregtwallace/legocerthub-frontend.git /src && \
+    cd /src && \
+    npm clean-install && \
+    npx vite build
+
+
+FROM golang:alpine AS backend_build
+
+ARG BACKEND_VERSION
+ARG CGO_ENABLED=1
+
+WORKDIR /
+
+RUN apk add git gcc musl-dev && \
+    git clone --depth 1 --branch "${BACKEND_VERSION}" https://github.com/gregtwallace/legocerthub-backend.git /src && \
+    cd /src && \
+    go build -o ./legocerthub_server ./cmd/api-server
+
+
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=backend_build /src/legocerthub_server .
+COPY --from=backend_build /src/config.default.yaml .
+COPY --from=frontend_build /src/dist ./frontend_build
+COPY ./README.md .
+COPY ./CHANGELOG.md .
+COPY ./LICENSE.md .
+
+RUN sh -c "echo \"bind_address: '0.0.0.0'\" > /app/data/config.yaml"
+
+EXPOSE 4050/tcp
+EXPOSE 4055/tcp
+EXPOSE 4060/tcp
+
+CMD /app/legocerthub_server
+


### PR DESCRIPTION
Hello :wave:

This PR adds container support! I wanted to try this out but preferred using a container over locally with the tgz. Haven't had a chance to test functionality yet but the container starts and I can login. This can be added to the pipeline to create (and maybe push?!) to a registry. Should also make supporting different cpu architectures easier.

Example build:
`docker build --build-arg=BACKEND_VERSION=v0.7.0 --build-arg=FRONTEND_VERSION=v0.7.0 -t legocerthub:v0.7.0 .`

Example run:
`docker run -d --name legocerthub -p 4050:4050 -p 4060:4060 legocerthub:v0.7.0`

Additional volumes/binds will likely make sense on exec. IE:
`docker run -d --name legocerthub -v /some/local/path/config.yaml:/app/config.yaml -p 4050:4050 -p 4060:4060 legocerthub:v0.7.0`

Cheers :beers: 
