### PR TITLE
Support multi arch images

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -22,6 +22,12 @@ jobs:
           ref: ${{ env.GITHUB_REF }}
           fetch-depth: 0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -49,6 +55,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Ahoy 👋 . I wanted to try this out, but my host is an arm64 host, which is not compatible with the currently published docker image. This change updates the github action to build a multi-arch docker image that supports both arm64 and amd64.