### PR TITLE
Fix acme.sh in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,12 @@ FROM alpine:latest
 
 WORKDIR /app
 
-# bash is needed in the container by the backend
+# acme.sh dependencies
 RUN apk add bash
+RUN apk add curl
+RUN mkdir -p /root/.acme.sh
 
+# copy app
 COPY --from=backend_build /src/lego-linux-amd64 .
 COPY --from=backend_build /src/config.default.yaml .
 COPY --from=frontend_build /src/dist ./frontend_build
@@ -44,6 +47,7 @@ COPY ./README.md .
 COPY ./CHANGELOG.md .
 COPY ./LICENSE.md .
 
+# make default config
 RUN sh -c "mkdir /app/data"
 RUN sh -c "printf '%s\n'                \
             'config_version: 0'         \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ FROM alpine:latest
 
 WORKDIR /app
 
+# bash is needed in the container by the backend
+RUN apt add bash
+
 COPY --from=backend_build /src/lego-linux-amd64 .
 COPY --from=backend_build /src/config.default.yaml .
 COPY --from=frontend_build /src/dist ./frontend_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM alpine:latest
 WORKDIR /app
 
 # bash is needed in the container by the backend
-RUN apt add bash
+RUN apk add bash
 
 COPY --from=backend_build /src/lego-linux-amd64 .
 COPY --from=backend_build /src/config.default.yaml .


### PR DESCRIPTION
Hi,
this Project looks very cool and i want to test it.
In my scenario I want to use LeGo Certhub to requests wildcard cert for host, which are not exposed to the internet.
To optain the Certs i will use the ame.sh challenge provider and after activating the challenge provider my LeGo Certhub container doesn't start any more.

Currently there is only **sh** available in the container and the container will crash if the [dns01acmesh](https://github.com/gregtwallace/legocerthub-backend/tree/master/pkg/challenges/providers/dns01acmesh) challenge provider is enabled.

The backend require **bash** to run the acme.sh challenge provider.

The [service.go](https://github.com/gregtwallace/legocerthub-backend/blob/master/pkg/challenges/providers/dns01acmesh/service.go) file from the [dns01acmesh](https://github.com/gregtwallace/legocerthub-backend/tree/master/pkg/challenges/providers/dns01acmesh) challenge provider checks in [line 65](https://github.com/gregtwallace/legocerthub-backend/blob/063648a7fa0585728ff4985ac10e20901150a804/pkg/challenges/providers/dns01acmesh/service.go#L65) for the path of the **bash** binary.