### PR TITLE
Fix acme.sh install into Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir -p /root/.acme.sh
 # copy app
 COPY --from=backend_build /src/lego-linux-amd64 .
 COPY --from=backend_build /src/config.default.yaml .
+COPY --from=backend_build /src/scripts/linux ./scripts
 COPY --from=frontend_build /src/dist ./frontend_build
 COPY ./README.md .
 COPY ./CHANGELOG.md .


### PR DESCRIPTION
Currently the Build process for the Docker Container doesn’t copy the Scripts folder into the finished docker image. Because of this the acme.sh folder doesn’t get copied which breaks the extension.

This addition to the dockerfile adds the scripts folder to the /app directory in the docker container so that the provided acme.sh configuration in the config.yaml can work and the user doesn't need to install the scripts inkl. acme.sh by hand.