### PR TITLE
Improve HealthCheck command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN sh -c "mkdir /app/data"
 # defer empty config file generation to Cert Warden on first run (if not manually made by user prior)
 
 # Note: Do not disable http redirect once https is configured or healthcheck will break
-HEALTHCHECK CMD curl --silent --output /dev/null --fail http://localhost:4050/certwarden/api/health || exit 1
+HEALTHCHECK CMD curl -Lk --silent --output /dev/null --fail http://localhost:4050/certwarden/api/health || exit 1
 
 # http / https server
 EXPOSE 4050/tcp 


### PR DESCRIPTION
This makes curl follow the redirect from http to https. Also disables SSL verification so that we can check the health  if https is using some certs signed by a private, not trusted by default CA.

As this connects from the container to the container that shouldn't be a security issue (if someone's doing a MITM inside the container, we have worst problems to deal with)